### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @with-ours/codebases-write


### PR DESCRIPTION
Adds a CODEOWNERS file so the `codebases-write` team is auto-requested as reviewers on new PRs. Approval is not required to merge (no 'Require review from Code Owners' rule).