### PR TITLE
fix: separate periodic flush from user-initiated flush

### DIFF
--- a/oursprivacy-android/src/main/java/com/oursprivacy/android/opmetrics/AnalyticsMessages.java
+++ b/oursprivacy-android/src/main/java/com/oursprivacy/android/opmetrics/AnalyticsMessages.java
@@ -106,6 +106,19 @@ import java.util.concurrent.TimeUnit;
         }
     }
 
+    /**
+     * Test-only: parks the worker thread inside a single message handler so the
+     * caller can deterministically queue follow-on messages before the worker
+     * starts draining them. {@code parked} fires once the worker is blocked;
+     * countDown {@code release} to let it resume.
+     */
+    /* package */ void parkWorker(CountDownLatch parked, CountDownLatch release) {
+        final Message m = Message.obtain();
+        m.what = BARRIER;
+        m.obj = new CountDownLatch[]{parked, release};
+        mWorker.runMessage(m);
+    }
+
     // ---------- worker ----------
 
     private final class Worker {
@@ -137,11 +150,14 @@ import java.util.concurrent.TimeUnit;
         }
 
         private void scheduleFlush(long delayMs) {
+            // FLUSH_PERIODIC is the recurring timer-driven flush. We coalesce
+            // only against ourselves — never against user-initiated FLUSH
+            // messages, which must survive to fire sendBatch().
             synchronized (mHandlerLock) {
                 if (mHandler == null) return;
-                mHandler.removeMessages(FLUSH);
+                mHandler.removeMessages(FLUSH_PERIODIC);
                 final Message m = Message.obtain();
-                m.what = FLUSH;
+                m.what = FLUSH_PERIODIC;
                 mHandler.sendMessageDelayed(m, delayMs);
             }
         }
@@ -161,7 +177,8 @@ import java.util.concurrent.TimeUnit;
                             }
                             break;
                         }
-                        case FLUSH: {
+                        case FLUSH:
+                        case FLUSH_PERIODIC: {
                             sendBatch();
                             scheduleFlush(mFlushInterval);
                             break;
@@ -180,6 +197,14 @@ import java.util.concurrent.TimeUnit;
                         case SENTINEL: {
                             final CountDownLatch latch = (CountDownLatch) msg.obj;
                             if (latch != null) latch.countDown();
+                            break;
+                        }
+                        case BARRIER: {
+                            final CountDownLatch[] gates = (CountDownLatch[]) msg.obj;
+                            gates[0].countDown();
+                            try { gates[1].await(); } catch (InterruptedException ignored) {
+                                Thread.currentThread().interrupt();
+                            }
                             break;
                         }
                         default:
@@ -253,6 +278,8 @@ import java.util.concurrent.TimeUnit;
     private static final int CLEAR_QUEUE = 2;
     private static final int KILL_WORKER = 3;
     private static final int SENTINEL = 4;
+    private static final int FLUSH_PERIODIC = 5;
+    private static final int BARRIER = 6;
 
     private static final String LOGTAG = "OursPrivacy.Analytics";
 }

--- a/oursprivacy-android/src/main/java/com/oursprivacy/android/opmetrics/OursPrivacyAPI.java
+++ b/oursprivacy-android/src/main/java/com/oursprivacy/android/opmetrics/OursPrivacyAPI.java
@@ -348,6 +348,12 @@ public class OursPrivacyAPI {
         if (mMessages != null) mMessages.hardKill();
     }
 
+    /** Test-only: park the worker so the caller can deterministically stack messages behind it. */
+    void parkWorkerForTests(java.util.concurrent.CountDownLatch parked,
+                            java.util.concurrent.CountDownLatch release) {
+        if (mMessages != null) mMessages.parkWorker(parked, release);
+    }
+
     void onBackground() {
         if (mConfig != null && mConfig.getFlushOnBackground()) {
             flush();

--- a/oursprivacy-android/src/test/java/com/oursprivacy/android/opmetrics/OursPrivacyIntegrationTest.java
+++ b/oursprivacy-android/src/test/java/com/oursprivacy/android/opmetrics/OursPrivacyIntegrationTest.java
@@ -324,6 +324,37 @@ public class OursPrivacyIntegrationTest {
     }
 
     @Test
+    public void backToBackFlushes_doNotDropTheSecondFlush() throws Exception {
+        // Regression: scheduleFlush() used to coalesce against the same message
+        // code as user-initiated flushes, so when the worker drained an explicit
+        // FLUSH it would removeMessages(FLUSH) — silently killing the next
+        // user-initiated FLUSH already queued behind it. Reset() exercises this
+        // pattern internally (flushNow before persistence wipe + caller's flush).
+        // Park the worker before any of the messages drain to make the race
+        // deterministic.
+        final OursPrivacyAPI op = newApi();
+        op.initialize(TOKEN, null);
+        assertTrue(op.awaitWorkerIdle(IDLE_TIMEOUT_MS));
+
+        final java.util.concurrent.CountDownLatch parked = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+        op.parkWorkerForTests(parked, release);
+        assertTrue("worker parked", parked.await(IDLE_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS));
+
+        op.flush();
+        op.track("between_flushes");
+        op.flush();
+
+        release.countDown();
+        assertTrue(op.awaitWorkerIdle(IDLE_TIMEOUT_MS));
+
+        assertEquals("second FLUSH must survive the first FLUSH's reschedule",
+                1, mNetwork.callCount());
+        assertEquals("between_flushes",
+                mNetwork.bodyAt(0).getJSONArray("data").getJSONObject(0).getString("event"));
+    }
+
+    @Test
     public void reset_regeneratesVisitorIdAndClearsDefaults() throws Exception {
         final OursPrivacyAPI op = newApi();
         op.initialize(TOKEN, null);


### PR DESCRIPTION
## Summary

- The recurring flush scheduler called `removeMessages(FLUSH)` when rescheduling, which also wiped any user-initiated `FLUSH` already queued behind it. Under load, a `flush()` could be silently dropped before `sendBatch()` ran.
- Introduce a dedicated `FLUSH_PERIODIC` message code so the scheduler only coalesces against its own messages. User-initiated `FLUSH` is never removed.
- Add a worker-park test hook and a regression test that deterministically reproduces the race.

## Test plan

- [x] `./gradlew test :oursprivacydemo:assembleDebug :oursprivacy-android:assembleRelease` passes
- [x] New `backToBackFlushes_doNotDropTheSecondFlush` fails against the prior code, passes with the fix
- [x] Existing integration suite still green